### PR TITLE
fix: color mode switcher

### DIFF
--- a/components/ColorModeSwitcher.vue
+++ b/components/ColorModeSwitcher.vue
@@ -11,11 +11,13 @@ const toggleColorMode = () => {
     @click="toggleColorMode"
     class="size-8 rounded-lg border-0 hover:cursor-pointer flex items-center justify-center bg-white dark:bg-zinc-9 hover:bg-gray-100 dark:hover:bg-zinc-8 p-0"
   >
-    <Icon
-      name="uil:moon"
-      class="size-5 text-zinc-2"
-      v-if="colorMode.preference === 'dark'"
-    />
-    <Icon name="uil:sun" class="size-5" v-else />
+    <ClientOnly>
+      <Icon
+        name="uil:moon"
+        class="size-5 text-zinc-2"
+        v-if="colorMode.preference === 'dark'"
+      />
+      <Icon name="uil:sun" class="size-5" v-else />
+    </ClientOnly>
   </button>
 </template>


### PR DESCRIPTION
Hello 👋,

You are using the local storage to store the theme of the website. Because of this, you're unable to know, server-side, if the user prefers dark mode or light mode (and even by using a cookie, you can't solve this issue since you're pre-rendering the website). So the content of the color mode switch must be rendered only on the client-side to avoid hydration issues.

When you pre-render the website, it will be white by default (with the sun in the in the switch) and once the JavaScript is loaded, it will use the local storage and if the user prefers dark mode, Vue will try to render the moon in the switch. But because of the hydration issue, it will keep the sun in the switch. This is why you need to render the content of the switch only on the client-side.
